### PR TITLE
:sparkles: Add an example of cc.get_attributes().

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/.ipynb_checkpoints

--- a/JupyterNotebooks/notebooks_and_constellation.ipynb
+++ b/JupyterNotebooks/notebooks_and_constellation.ipynb
@@ -459,6 +459,23 @@
     "\n",
     "You generally don't want all of the attributes that CONSTELLATION knows about. For example, the x,y,z coordinates are rarely useful when you're analysing data. The ``get_dataframe()`` method allows you to specify only the attributes you want. Not only does this use less space in the dataframe, but particularly for larger graphs, it can greatly reduce the time taken to get the data into a dataframe.\n",
     "\n",
+    "First we'll find out what graph, node, and transaction attributes exist. The `get_attributes()` method returns a dictionary mapping attribute names to their CONSTELLATION types. For consistency with the other method return values, the attribute names are prefixed with `graph.`, `source.`, and `transaction.`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "attrs = cc.get_attributes()\n",
+    "attrs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "To specify just the attributes you want, pass a list of attribute names using the ``attrs`` parameter."
    ]
   },


### PR DESCRIPTION
The notebooks_and_constellation notebook has been updated to demonstrate the new `constellation_client.get_attributes()` method.